### PR TITLE
fixed timestamp type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(ichthus_lidar_driver)
 
 add_compile_options(-std=c++11)
 
-#find_package(PCL REQUIRED)
-find_package(autoware_build_flags REQUIRED)
+find_package(PCL REQUIRED)
+# find_package(autoware_build_flags REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
 					roscpp
 					sensor_msgs
@@ -71,7 +71,7 @@ add_library(ichthus_lidar_driver
 set(libpcap_LIBRARIES "-lpcap")
 
 find_package(CUDA)
-AW_CHECK_CUDA()
+# AW_CHECK_CUDA()
 if (USE_CUDA)
     message("-- USING ACCELERATED TRANSFORM --")
     message("Version: " ${CUDA_VERSION})

--- a/src/ichthus_lidar_driver/common/lidar.cpp
+++ b/src/ichthus_lidar_driver/common/lidar.cpp
@@ -306,8 +306,8 @@ namespace VLP16
                 // point.ts = msg.ts.tv_sec();
                 if (need_update == true)
                 {
-                  sec = (float)((int)(*vector_msg[i]).ts.sec % 1000000); // fixed by qjin, 1. long->float , 2. upper value not needed
-                  usec = (float)((int)(*vector_msg[i]).ts.nsec / 1000);  // fixed by qjin, 1. long->float
+                  sec = (float)((int)((*vector_msg[i]).ts.sec) % 1000000); // fixed by qjin, 1. long->float , 2. upper value not needed
+                  usec = (float)((int)((*vector_msg[i]).ts.nsec) / 1000);  // fixed by qjin, 1. long->float
                   need_update = false;
                 }
                 point.normal_y = sec;
@@ -451,8 +451,8 @@ namespace OSI64
 
           if (need_update == true)
           {
-            sec = (float)(msg.ts.sec % 1000000); // fixed by qjin, 1. long->float , 2. upper value not needed
-            usec = (float)(msg.ts.nsec / 1000); // fixed by qjin, 1. long->float
+            sec = (float)((int)(msg.ts.sec) % 1000000); // fixed by qjin, 1. long->float , 2. upper value not needed
+            usec = (float)((int)(msg.ts.nsec) / 1000); // fixed by qjin, 1. long->float
             need_update = false;
           }
           point.normal_y = sec;

--- a/src/ichthus_lidar_driver/common/lidar.cpp
+++ b/src/ichthus_lidar_driver/common/lidar.cpp
@@ -306,8 +306,8 @@ namespace VLP16
                 // point.ts = msg.ts.tv_sec();
                 if (need_update == true)
                 {
-                  sec = (*vector_msg[i]).ts.sec;
-                  usec = (*vector_msg[i]).ts.nsec / 1000;
+                  sec = (float)((int)(*vector_msg[i]).ts.sec % 1000000); // fixed by qjin, 1. long->float , 2. upper value not needed
+                  usec = (float)((int)(*vector_msg[i]).ts.nsec / 1000);  // fixed by qjin, 1. long->float
                   need_update = false;
                 }
                 point.normal_y = sec;
@@ -451,8 +451,8 @@ namespace OSI64
 
           if (need_update == true)
           {
-            sec = msg.ts.sec;
-            usec = msg.ts.nsec / 1000;
+            sec = (float)(msg.ts.sec % 1000000); // fixed by qjin, 1. long->float , 2. upper value not needed
+            usec = (float)(msg.ts.nsec / 1000); // fixed by qjin, 1. long->float
             need_update = false;
           }
           point.normal_y = sec;


### PR DESCRIPTION
1. timestamp type changed in common/lidar.cpp
(long)ts.sec -> (float)ts.sec
(long)ts.nsec -> (float)ts.nsec

2. removed upper value in ts.sec
msg.ts.sec -> msg.ts.sec % 100000

3. removed Autoware flag in CMakeLists